### PR TITLE
Fixed panic: runtime error: slice bounds out of range [:-1]

### DIFF
--- a/ngorm.go
+++ b/ngorm.go
@@ -289,8 +289,11 @@ func (db *DB) AutomigrateSQL(models ...interface{}) (*model.Expr, error) {
 		}
 		if e.Scope.MultiExpr {
 			for _, expr := range e.Scope.Exprs {
+				k := expr.Q
 				i := strings.Index(expr.Q, "(")
-				k := expr.Q[:i]
+				if i > 0 {
+					k = expr.Q[:i]
+				}
 				if _, ok := keys[k]; !ok {
 					buf.WriteString("\t" + expr.Q + ";\n")
 					keys[k] = true


### PR DESCRIPTION
When adding a field to a model, there is no brackets in the query. It leads to panic because **i** is negative index.
![image](https://user-images.githubusercontent.com/4648441/133989918-cbb0c113-c223-490b-8e05-2bcec51b82dc.png)
